### PR TITLE
resolves #4

### DIFF
--- a/patches/smart_autocomplete-roundcube-1.2.0-patch.diff
+++ b/patches/smart_autocomplete-roundcube-1.2.0-patch.diff
@@ -59,8 +59,8 @@ index 3023ecf..31480ca 100644
 -                        $contact = array('name' => $contact, 'type' => $sql_arr['_type']);
 +                        $contact = array(
 +                            'name'   => $contact,
-+                            'type'   => $sql_arr['_type'],
-+                            'id'     => $sql_arr['contact_id'],
++                            'type'   => $record['_type'],
++                            'id'     => $record['contact_id'],
 +                            'source' => $abook_id,
 +                        );
  


### PR DESCRIPTION
The patch for roundcube 1.2.0 doesn't work with 1.2.4, I don't know if we should put this in here or create a specific patch for 1.2.4. We need to spot at what version of roundcube did the $sql_arr variable disappeared in favor of $record and go from there.

